### PR TITLE
feat: markdown-it transcript, pierre diffs, oxlint, vitest lanes, adrs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,52 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: oxlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+
+  unit:
+    name: unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+      - run: bun install --frozen-lockfile
+      - run: bun run test:unit
+
+  integration:
+    name: integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+      - run: bun install --frozen-lockfile
+      - run: bun run test:integration
+
   build:
+    name: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -15,3 +60,11 @@ jobs:
           install: true
       - run: bun install --frozen-lockfile
       - run: mise run build
+
+  all:
+    name: all checks pass
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, unit, integration, build]
+    if: ${{ always() }}
+    steps:
+      - run: echo "${{ needs.lint.result }} ${{ needs.typecheck.result }} ${{ needs.unit.result }} ${{ needs.integration.result }} ${{ needs.build.result }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,28 @@
+name: e2e
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: electron e2e
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: true
+      - run: bun install --frozen-lockfile
+      - run: npm install -g @earendil-works/pi-coding-agent
+      - run: mise run build
+      - run: mise run test:e2e
+      - name: upload test artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openpi-e2e
+          path: |
+            /tmp/pidex-*.png
+            test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,8 @@ jobs:
   e2e:
     name: electron e2e
     runs-on: macos-latest
+    env:
+      NODE_ENV: development
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -15,7 +17,11 @@ jobs:
           install: true
       - run: bun install --frozen-lockfile
       - run: npm install -g @earendil-works/pi-coding-agent
-      - run: mise run build
+      - run: bunx tsc -p tsconfig.main.json
+      - run: bunx tsc -p tsconfig.preload.json
+      - run: bunx vite build
+      - run: mise run dev:vite &
+      - run: bunx wait-on http://localhost:5173
       - run: mise run test:e2e
       - name: upload test artefacts
         if: always()

--- a/.mise.toml
+++ b/.mise.toml
@@ -44,7 +44,7 @@ run = [
 
 [tasks."test:e2e"]
 description = "Run e2e tests against the live Electron app"
-run = "bunx vitest run --project e2e"
+run = "bunx vitest run --config vitest.e2e.config.ts"
 
 [settings]
 experimental = true

--- a/.mise.toml
+++ b/.mise.toml
@@ -20,8 +20,12 @@ run = [
 ]
 
 [tasks.build]
-description = "Production build: compile main/preload + bundle renderer"
+description = "Production build: lint, typecheck, test, bundle"
 run = [
+  "bun run lint",
+  "bun run typecheck",
+  "bun run test:unit",
+  "bun run test:integration",
   "bunx tsc -p tsconfig.main.json",
   "bunx tsc -p tsconfig.preload.json",
   "bunx vite build",
@@ -30,6 +34,17 @@ run = [
 [tasks.start]
 description = "Run the production build"
 run = "bunx electron ."
+
+[tasks.test]
+description = "Run unit + integration tests"
+run = [
+  "bunx vitest run --project unit",
+  "bunx vitest run --project integration",
+]
+
+[tasks."test:e2e"]
+description = "Run e2e tests against the live Electron app"
+run = "bunx vitest run --project e2e"
 
 [settings]
 experimental = true

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,21 @@
+{
+  "categories": {
+    "correctness": "error",
+    "suspicious": "allow",
+    "perf": "allow",
+    "style": "allow",
+    "restriction": "allow",
+    "nursery": "allow"
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "ignorePatterns": [
+    "dist/**",
+    "node_modules/**",
+    ".vite/**",
+    "src/renderer/assets/fonts/**"
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -6,24 +6,63 @@
       "name": "openpi",
       "dependencies": {
         "@chenglou/pretext": "^0.0.6",
+        "@pierre/diffs": "^1.2.12",
+        "markdown-it": "^14.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "^26.1.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
         "concurrently": "^9.1.0",
         "electron": "^41.0.0",
+        "jsdom": "^29.1.1",
+        "oxlint": "^1.74.0",
+        "playwright-core": "^1.61.1",
         "typescript": "^6.0.0",
         "vite": "^8.0.0",
+        "vitest": "^4.1.10",
         "wait-on": "^8.0.0",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
     "@chenglou/pretext": ["@chenglou/pretext@0.0.6", "", {}, "sha512-U10s4tFeyu3oVHfXuNWwZSKqHXefhaigpcBkGj60qQFRJ+yUoQ+ez3cGJelP7BWDAB58HCgjcTSmOcg+77afBQ=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.9", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
 
@@ -32,6 +71,8 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
 
@@ -45,9 +86,55 @@
 
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.74.0", "", { "os": "android", "cpu": "arm" }, "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.74.0", "", { "os": "android", "cpu": "arm64" }, "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.74.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.74.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.74.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.74.0", "", { "os": "linux", "cpu": "arm" }, "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.74.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.74.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.74.0", "", { "os": "linux", "cpu": "none" }, "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.74.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.74.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.74.0", "", { "os": "none", "cpu": "arm64" }, "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.74.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.74.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
+
+    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
+
+    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+
+    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 
@@ -81,19 +168,61 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1" } }, "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/types": "4.3.1" } }, "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A=="],
+
+    "@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
 
     "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
@@ -103,17 +232,43 @@
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
@@ -125,7 +280,15 @@
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -137,11 +300,23 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
@@ -153,9 +328,17 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -165,11 +348,15 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -180,6 +367,10 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
@@ -225,13 +416,29 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "joi": ["joi@18.2.1", "", { "dependencies": { "@hapi/address": "^5.1.1", "@hapi/formula": "^3.0.2", "@hapi/hoek": "^11.0.7", "@hapi/pinpoint": "^2.0.1", "@hapi/tlds": "^1.1.1", "@hapi/topo": "^6.0.2", "@standard-schema/spec": "^1.1.0" } }, "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -265,19 +472,49 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
+
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "markdown-it": ["markdown-it@14.3.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.5.0", "linkify-it": "^5.0.2", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw=="],
+
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -289,9 +526,21 @@
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "oxlint": ["oxlint@1.74.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.74.0", "@oxlint/binding-android-arm64": "1.74.0", "@oxlint/binding-darwin-arm64": "1.74.0", "@oxlint/binding-darwin-x64": "1.74.0", "@oxlint/binding-freebsd-x64": "1.74.0", "@oxlint/binding-linux-arm-gnueabihf": "1.74.0", "@oxlint/binding-linux-arm-musleabihf": "1.74.0", "@oxlint/binding-linux-arm64-gnu": "1.74.0", "@oxlint/binding-linux-arm64-musl": "1.74.0", "@oxlint/binding-linux-ppc64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-gnu": "1.74.0", "@oxlint/binding-linux-riscv64-musl": "1.74.0", "@oxlint/binding-linux-s390x-gnu": "1.74.0", "@oxlint/binding-linux-x64-gnu": "1.74.0", "@oxlint/binding-linux-x64-musl": "1.74.0", "@oxlint/binding-openharmony-arm64": "1.74.0", "@oxlint/binding-win32-arm64-msvc": "1.74.0", "@oxlint/binding-win32-ia32-msvc": "1.74.0", "@oxlint/binding-win32-x64-msvc": "1.74.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.24.0", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA=="],
+
     "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -299,13 +548,23 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
@@ -313,7 +572,19 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
 
@@ -325,6 +596,8 @@
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -335,21 +608,53 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
+    "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.4.9", "", { "dependencies": { "tldts-core": "^7.4.9" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA=="],
+
+    "tldts-core": ["tldts-core@7.4.9", "", {}, "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -357,17 +662,51 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "wait-on": ["wait-on@8.0.5", "", { "dependencies": { "axios": "^1.12.1", "joi": "^18.0.1", "lodash": "^4.17.21", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -376,6 +715,12 @@
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@types/cacheable-request/@types/node": ["@types/node@24.12.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ=="],
 
@@ -392,6 +737,10 @@
     "electron/@types/node": ["@types/node@24.12.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ=="],
 
     "global-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.18", "", {}, "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw=="],
 

--- a/docs/adr/0001-markdown-it-for-transcript.md
+++ b/docs/adr/0001-markdown-it-for-transcript.md
@@ -1,0 +1,14 @@
+# ADR 0001 — Use markdown-it for transcript rendering
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The Pi coding agent streams structured markdown to the renderer (assistant text, code blocks, lists, tables, blockquotes). The renderer needs a CommonMark-compliant parser that is safe by default and supports the streaming update pattern (re-parse on every token delta). Candidate libraries were `marked`, `remark`, `markdown-it`, and `micromark`. The previous decision point in this repo's research notes (`2026-06-26 - Spanner Layer - Search, Syntax, Markdown, Diff.md`) ruled out `marked` because it is unsafe by default and requires an additional sanitiser. We had been using `marked` plus `DOMPurify` as a workaround; the sanitiser is dead weight if the parser is safe by default.
+
+- **Decision**: Switch the transcript renderer to `markdown-it` with `html: false`, `breaks: true`, `linkify: true`, `typographer: true`. Drop `DOMPurify` entirely.
+
+- **Consequences**:
+  - No DOMPurify dependency, smaller bundle and surface area.
+  - Safe by default against HTML/script injection from agent output.
+  - Token-stream architecture re-parses cleanly on streaming deltas (each delta re-validates).
+  - Performance is ~8ms on 10k words vs `marked`'s ~3ms; negligible at transcript sizes.
+  - Plugins available for tables, footnotes, task lists, math later if needed.
+  - If math/MDX becomes a requirement, the path forward is `remark` + `rehype-sanitize`, not back to `marked`.

--- a/docs/adr/0002-pierre-diffs-renderer.md
+++ b/docs/adr/0002-pierre-diffs-renderer.md
@@ -1,0 +1,13 @@
+# ADR 0002 — Adopt @pierre/diffs as the diff renderer
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The workbench surfaces code changes from agent runs (file-level diffs from `bash`/`edit`/`write` tools). The change surface needs a renderer that handles large files, performs syntax highlighting consistently with code blocks, and supports future merge-conflict UI. The repo's research note (`2026-06-26 - Spanner Layer - Search, Syntax, Markdown, Diff.md`) ranked candidates: `@pierre/diffs`, `react-diff-viewer`, `react-virtualized-diff`, raw `jsdiff`. Pierre was the recommended primary — same engine used by Claude Code, Codex, Cursor, and OpenChamber — and pairs naturally with `shiki` for syntax highlighting. The earlier "Pidex - Pi Ecosystem Technology Stack Research" note (`2026-05-31`) flagged that `openchamber` already uses `@pierre/diffs 1.1.0-beta.13`.
+
+- **Decision**: Adopt `@pierre/diffs` as the primary diff engine. Wrap its React `<PatchDiff>` component in `<PierreDiff>` to provide a small API (`oldFile`, `newFile`, `filename`) and a unified-patch generator. Use `theme: 'pierre-dark'` to match the OpenPi palette.
+
+- **Consequences**:
+  - Diff renderer scales to 10k+ lines via per-line virtualisation in Shadow DOM.
+  - Same engine as OpenChamber / Claude Code / Codex / Cursor — visual parity for shared screenshots.
+  - Adds ~1MB of language packs to the bundle; acceptable for an agent workbench, with `chunks larger than 500kB` warning expected until we code-split Shiki languages.
+  - Plumbs into future "review session" views where merge-conflict UI will reuse the same renderer.
+  - Until file content plumbed from the main process, the renderer ships a `Fig. 02 | Pierre diff probe` sample in the empty state.

--- a/docs/adr/0003-pretext-measurement.md
+++ b/docs/adr/0003-pretext-measurement.md
@@ -1,0 +1,12 @@
+# ADR 0003 — Use @chenglou/pretext for text measurement only
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The workbench renders long session timelines (10k+ messages in long sessions). The renderer needs a way to know row heights for the status-bar measurement counter and, eventually, for virtualised row sizing before mounting DOM. `@chenglou/pretext` (Cheng Lou) provides Canvas-2D-based text measurement that is ~300× faster than DOM-based measurement for re-layout. The original OpenPi architecture (`docs/openpi-architecture.md`) called for Pretext specifically as a "layout dispatch" primitive.
+
+- **Decision**: Use `@chenglou/pretext` strictly for text measurement — row counting for the status bar today, and (future) row heights for virtualised lists. Do not use it for glyph rendering; rely on `markdown-it` + browser text layout for that.
+
+- **Consequences**:
+  - The status-bar `rows measured` counter is meaningful (it reflects an actual measurement, not a wall-clock approximation).
+  - No need to maintain a parallel `getBoundingClientRect` measurement path.
+  - When the renderer virtualises the timeline, Pretext's `layoutWithLines` is already wired in and ready.
+  - Avoids the canvas-vs-DOM font metrics drift by only measuring, never rendering.

--- a/docs/adr/0004-three-lane-testing.md
+++ b/docs/adr/0004-three-lane-testing.md
@@ -1,0 +1,16 @@
+# ADR 0004 — Three-lane testing with Vitest and Playwright
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The workbench has multiple execution surfaces — pure TS reducers (timeline), React components (markdown rendering, diff probe), and a live Electron process (spawning `pi` over RPC). A single test lane cannot cover all three cost-effectively: pure unit tests don't catch DOM regressions, DOM tests don't catch RPC contract drift, and Playwright-only is too slow for tight feedback. The previous PRs shipped code without tests; this ADR sets the lane model.
+
+- **Decision**: Three lanes under Vitest projects plus a Playwright Electron runner:
+  - **Unit** — Node environment, covers pure functions (`timeline.ts` reducer, `sessions.ts` parser). Fast, deterministic, runs in CI on every PR.
+  - **Integration** — jsdom environment with React Testing Library, covers component output (`Markdown.tsx` rendering, escaping, lists, tables). Runs in CI on every PR.
+  - **E2E** — Node environment with Playwright Electron, drives the full app against a real `pi` subprocess. Runs on `macos-latest` runners only (Electron binary shape) and is manual (`workflow_dispatch`) because the `pi` runtime requires user OAuth.
+
+- **Consequences**:
+  - PR feedback loop is fast (unit + integration complete in seconds).
+  - E2E is gated to manual trigger and macos to avoid flaky CI runs.
+  - Tests live under `tests/{unit,integration,e2e}/`; config files in `vitest.{unit,integration,e2e}.config.ts`.
+  - Coverage targets left intentionally loose while we stabilise the surface.
+  - Future: split E2E into contract tests (mock pi subprocess) plus one full-driver smoke test.

--- a/docs/adr/0005-oxlint.md
+++ b/docs/adr/0005-oxlint.md
@@ -1,0 +1,12 @@
+# ADR 0005 — Use oxlint as the lint tool
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The repo had no lint gate. ESLint is the default but slow to install and configure, and many of its plugins don't work cleanly with React 19 + Vitest. The OpenPi project has a single-language (TypeScript) codebase and needs correctness guarantees, not style debates.
+
+- **Decision**: Adopt `oxlint` for CI lint. Configure it via `.oxlintrc.json` with the `correctness` category as error and the rest allowed. Style formatting is left to manual conventions.
+
+- **Consequences**:
+  - Lint runs in CI under a separate job so it doesn't block other jobs.
+  - Only correctness failures block merges; suspicious/style warnings are noise we don't have time to debate today.
+  - When we need formatting, we'll reach for `biome` (single binary, formatter + lint) — not ESLint + Prettier.
+  - The repo can add ESLint for a small set of rules if a specific class of bug emerges that oxlint doesn't catch.

--- a/docs/adr/0006-pi-runtime-rpc.md
+++ b/docs/adr/0006-pi-runtime-rpc.md
@@ -1,0 +1,13 @@
+# ADR 0006 — Pi runtime integration via JSONL RPC
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: OpenPi is an Electron workbench for the Pi coding agent. Pi supports four runtime modes (`interactive`, `print/JSON`, `RPC`, `SDK`). The renderer needs streaming events and prompt submission. Embedding the SDK in-process bloats the renderer with Node-only dependencies; interactive mode is TUI-only. RPC mode is the documented headless protocol — JSON lines over stdin/stdout, `prompt`/`get_state`/`get_messages`/`get_commands` commands, `agent_start`/`message_update`/`tool_execution_*` events.
+
+- **Decision**: Spawn `pi --mode rpc` from the Electron main process per active session tab. Line-buffer stdout on `\n` only (no `readline` — the protocol forbids U+2028/U+2029 splitting). Forward events to the renderer over `webContents.send`. Re-emit Pi errors as `openpi:session:exit`. Validate `sessionFile` is under `~/.pi/agent/sessions` before resume.
+
+- **Consequences**:
+  - Strong process boundary; renderer never sees Node APIs beyond the typed bridge.
+  - One Pi subprocess per session tab keeps event routing simple.
+  - Sessions killed on tab close, on app quit, on window-all-closed.
+  - The renderer is fully testable without Pi: `applyEvent` is a pure reducer over RPC events.
+  - Future: a single RPC supervisor for many concurrent sessions is possible (`new_session` rather than respawn); we haven't needed it.

--- a/docs/adr/0007-native-tab-bar.md
+++ b/docs/adr/0007-native-tab-bar.md
@@ -1,0 +1,13 @@
+# ADR 0007 — Native tab bar with hidden-inset title bar
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The workbench has a workspace/session model with multiple open sessions. macOS users expect Chrome-style native tabs (`NSWindow tabbingMode`) OR a custom drag region with native traffic-light controls. The original OpenPi brief calls for "few clicks, fast switching, high awareness" and a "workspace-first" mental model — both benefit from a tab strip at the top of the window.
+
+- **Decision**: Use `titleBarStyle: 'hiddenInset'` on the `BrowserWindow`. Reserve `84px` of left padding on the renderer tab strip to clear the macOS traffic lights at the inset position. Mark the tab strip with `-webkit-app-region: drag` so the user can drag the window by the strip; mark every interactive child with `no-drag` so buttons remain clickable. Render the tab strip in-app with custom styles.
+
+- **Consequences**:
+  - Native window controls without losing the dark app background under them.
+  - User drags the window by the tab strip area.
+  - Avoids native NSWindow tab bar (which would push our renderer design into macOS chrome conventions).
+  - Windows/Linux: the inset still works but traffic-light buttons don't render — the strip just feels like a normal toolbar.
+  - Pair with custom buttons always inside `no-drag` regions, never the strip itself.

--- a/docs/adr/0008-pi-dev-design-system.md
+++ b/docs/adr/0008-pi-dev-design-system.md
@@ -1,0 +1,13 @@
+# ADR 0008 — Adopt pi.dev design system for visual language
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: The workbench is a desktop wrapper around the Pi coding agent. The Pi product (pi.dev) has its own distinctive visual language: deep ink canvas `#0d1116`, moonstone text, tidal-blue accent, terracotta rust, Departure Mono labels, Commit Mono code, bracketed buttons `[ ACTION ]`, corner-bracketed figure frames, lowercase `›` and `$` shell prompts. Building a separate design system would feel disjointed.
+
+- **Decision**: Mirror the pi.dev design system in OpenPi. Bundle `Commit Mono` (OFL) and `Departure Mono` (OFL) locally; fall back to system serifs/mono for the licensed Plantin MT Pro. Tokens live in `src/renderer/design-system/tokens.css` and components in `components.css`.
+
+- **Consequences**:
+  - Screenshots from OpenPi feel like native Pi product surfaces.
+  - Designers familiar with Pi can transfer work without re-learning a design system.
+  - Token names match Pi's published names (`--bg-deep`, `--accent`, `--panel`) — easy to grep and update.
+  - Local font assets ship ~850KB; acceptable for desktop.
+  - No licensing risk (both bundled fonts are OFL; Plantin fallback uses system Georgia).

--- a/docs/adr/0009-calver-releases.md
+++ b/docs/adr/0009-calver-releases.md
@@ -1,0 +1,13 @@
+# ADR 0009 — Calendar-versioned releases via GitHub Actions
+
+- **Status**: Accepted (2026-07-19)
+- **Context**: This is a personal, low-traffic workbench. Semver (X.Y.Z) imposes friction for solo projects where breaking changes are frequent and there's no public API contract. Pi's CLI uses semver; we don't.
+
+- **Decision**: Adopt CalVer (`YYYY.0M.0D`) with a `-N` suffix for same-day re-releases. On push to `main`, the `release.yml` workflow computes the tag (e.g. `2026.07.19`, `2026.07.19-2`) and creates a GitHub release with auto-generated notes.
+
+- **Consequences**:
+  - Predictable, sortable, machine-friendly tags.
+  - No "is this a breaking change" ceremony — every push to main tags a release.
+  - Dropped `release-please` (semver, PR-based) for a small workflow that just calls `gh release create --generate-notes`.
+  - Inconsistent with Pi CLI semver — keep documentation clear that OpenPi tags are CalVer.
+  - If we ever publish a public API, we revisit and add semver alongside.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+ADRs document significant architectural choices made in OpenPi.
+
+Each ADR follows this shape:
+
+- **Status** — Accepted / Superseded / Deprecated
+- **Context** — What problem we faced and the options we considered
+- **Decision** — What we chose
+- **Consequences** — Trade-offs, costs, and follow-up work
+
+## Index
+
+| # | Decision | Status |
+|---|----------|--------|
+| [0001](0001-markdown-it-for-transcript.md) | Use markdown-it for transcript rendering | Accepted |
+| [0002](0002-pierre-diffs-renderer.md) | Adopt @pierre/diffs as the diff renderer | Accepted |
+| [0003](0003-pretext-measurement.md) | Use @chenglou/pretext for text measurement only | Accepted |
+| [0004](0004-three-lane-testing.md) | Three-lane testing with Vitest and Playwright | Accepted |
+| [0005](0005-oxlint.md) | Use oxlint as the lint tool | Accepted |
+| [0006](0006-pi-runtime-rpc.md) | Pi runtime integration via JSONL RPC | Accepted |
+| [0007](0007-native-tab-bar.md) | Native tab bar with hidden-inset title bar | Accepted |
+| [0008](0008-pi-dev-design-system.md) | Adopt pi.dev design system for visual language | Accepted |
+| [0009](0009-calver-releases.md) | Calendar-versioned releases via GitHub Actions | Accepted |

--- a/package.json
+++ b/package.json
@@ -7,22 +7,38 @@
   "scripts": {
     "dev": "mise run dev",
     "build": "mise run build",
-    "start": "mise run start"
+    "start": "mise run start",
+    "lint": "oxlint src tests",
+    "typecheck": "bunx tsc -p tsconfig.json --noEmit && bunx tsc -p tsconfig.main.json --noEmit && bunx tsc -p tsconfig.preload.json --noEmit",
+    "test": "mise run test",
+    "test:unit": "bunx vitest run --project unit",
+    "test:integration": "bunx vitest run --project integration",
+    "test:e2e": "bunx vitest run --config vitest.e2e.config.ts",
+    "test:all": "bunx vitest run"
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",
+    "@pierre/diffs": "^1.2.12",
+    "markdown-it": "^14.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^26.1.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",
     "concurrently": "^9.1.0",
     "electron": "^41.0.0",
+    "jsdom": "^29.1.1",
+    "oxlint": "^1.74.0",
+    "playwright-core": "^1.61.1",
     "typescript": "^6.0.0",
     "vite": "^8.0.0",
+    "vitest": "^4.1.10",
     "wait-on": "^8.0.0"
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import fs from 'fs';
 import path from 'path';
 import { listSessions, listWorkspaces, SESSIONS_ROOT } from './sessions';
@@ -8,6 +8,27 @@ const isDev = !app.isPackaged;
 const sessions = new Map<string, RpcSession>();
 let sessionSeq = 0;
 let mainWindow: BrowserWindow | null = null;
+
+function customWorkspacesFile(): string {
+  return path.join(app.getPath('userData'), 'workspaces.json');
+}
+
+function readCustomWorkspaces(): string[] {
+  try {
+    const raw = fs.readFileSync(customWorkspacesFile(), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function addCustomWorkspace(cwd: string): void {
+  const existing = readCustomWorkspaces();
+  if (!existing.includes(cwd)) {
+    fs.writeFileSync(customWorkspacesFile(), JSON.stringify([...existing, cwd], null, 2));
+  }
+}
 
 function sendToRenderer(channel: string, payload: unknown) {
   mainWindow?.webContents.send(channel, payload);
@@ -42,7 +63,19 @@ function createWindow() {
   });
 }
 
-ipcMain.handle('openpi:workspaces', () => listWorkspaces());
+ipcMain.handle('openpi:workspaces', () => listWorkspaces(readCustomWorkspaces()));
+
+ipcMain.handle('openpi:workspace:add', async () => {
+  if (!mainWindow) return { error: 'no window' };
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: 'Add workspace',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (result.canceled || result.filePaths.length === 0) return { error: 'cancelled' };
+  const cwd = result.filePaths[0];
+  addCustomWorkspace(cwd);
+  return { cwd };
+});
 
 ipcMain.handle('openpi:sessions', (_e, dirName: string) => {
   if (typeof dirName !== 'string') return [];
@@ -88,6 +121,14 @@ ipcMain.handle(
 
 ipcMain.handle('openpi:session/abort', (_e, sessionId: string) => {
   sessions.get(sessionId)?.abort();
+});
+
+ipcMain.handle('openpi:session/commands', async (_e, sessionId: string) => {
+  const session = sessions.get(sessionId);
+  if (!session) return { commands: [] };
+  const response = await session.getCommands();
+  const data = response.data as { commands?: unknown[] } | undefined;
+  return { commands: response.success ? data?.commands ?? [] : [] };
 });
 
 ipcMain.handle('openpi:session/close', (_e, sessionId: string) => {

--- a/src/main/rpc.ts
+++ b/src/main/rpc.ts
@@ -1,7 +1,12 @@
 import { spawn, type ChildProcess } from 'child_process';
 import fs from 'fs';
 
-const PI_CANDIDATES = ['pi', '/opt/homebrew/bin/pi', '/usr/local/bin/pi'];
+const PI_CANDIDATES = [
+  'pi',
+  '/opt/homebrew/bin/pi',
+  '/usr/local/bin/pi',
+  '/usr/bin/pi',
+];
 
 type RpcEvent = Record<string, unknown> & { type: string };
 

--- a/src/main/rpc.ts
+++ b/src/main/rpc.ts
@@ -110,6 +110,10 @@ class RpcSession {
     return this.command({ type: 'get_messages' });
   }
 
+  getCommands() {
+    return this.command({ type: 'get_commands' });
+  }
+
   prompt(text: string, streaming: boolean) {
     const cmd: Record<string, unknown> = { type: 'prompt', message: text };
     if (streaming) cmd.streamingBehavior = 'steer';

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -17,6 +17,7 @@ type WorkspaceInfo = {
 type SessionInfo = {
   id: string;
   file: string;
+  cwd: string;
   title: string;
   model: string;
   timestamp: string;
@@ -48,6 +49,7 @@ function parseSession(file: string): SessionInfo | null {
   try {
     const lines = readLines(file);
     let id = '';
+    let cwd = '';
     let timestamp = '';
     let title = '';
     let model = '';
@@ -62,6 +64,7 @@ function parseSession(file: string): SessionInfo | null {
       }
       if (entry.type === 'session') {
         id = String(entry.id ?? '');
+        cwd = String(entry.cwd ?? '');
         timestamp = String(entry.timestamp ?? '');
         continue;
       }
@@ -78,7 +81,7 @@ function parseSession(file: string): SessionInfo | null {
       }
     }
     if (!id) return null;
-    return { id, file, title: title || '(empty session)', model, timestamp, messageCount };
+    return { id, file, cwd, title: title || '(empty session)', model, timestamp, messageCount };
   } catch {
     return null;
   }
@@ -97,53 +100,71 @@ function gitBranch(cwd: string): Promise<string> {
   });
 }
 
-async function listWorkspaces(): Promise<WorkspaceInfo[]> {
-  if (!fs.existsSync(SESSIONS_ROOT)) return [];
-  const dirs = fs
-    .readdirSync(SESSIONS_ROOT, { withFileTypes: true })
-    .filter(d => d.isDirectory())
-    .map(d => d.name);
+async function listWorkspaces(extraCwds: string[] = []): Promise<WorkspaceInfo[]> {
+  const byDir = new Map<string, WorkspaceInfo>();
+  if (fs.existsSync(SESSIONS_ROOT)) {
+    const dirs = fs
+      .readdirSync(SESSIONS_ROOT, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
 
-  const workspaces: WorkspaceInfo[] = [];
-  for (const dirName of dirs) {
-    const dirPath = path.join(SESSIONS_ROOT, dirName);
-    const files = fs
-      .readdirSync(dirPath)
-      .filter(f => f.endsWith('.jsonl'))
-      .map(f => path.join(dirPath, f));
-    if (files.length === 0) continue;
+    for (const dirName of dirs) {
+      const dirPath = path.join(SESSIONS_ROOT, dirName);
+      const files = fs
+        .readdirSync(dirPath)
+        .filter(f => f.endsWith('.jsonl'))
+        .map(f => path.join(dirPath, f));
+      if (files.length === 0) continue;
 
-    let cwd = '';
-    let lastActive = '';
-    for (const file of files) {
-      const stat = fs.statSync(file);
-      if (stat.mtime.toISOString() > lastActive) lastActive = stat.mtime.toISOString();
-      if (!cwd) {
-        for (const line of readLines(file, 64 * 1024)) {
-          if (!line) continue;
-          try {
-            const entry = JSON.parse(line);
-            if (entry.type === 'session' && typeof entry.cwd === 'string') {
-              cwd = entry.cwd;
+      let cwd = '';
+      let lastActive = '';
+      for (const file of files) {
+        const stat = fs.statSync(file);
+        if (stat.mtime.toISOString() > lastActive) lastActive = stat.mtime.toISOString();
+        if (!cwd) {
+          for (const line of readLines(file, 64 * 1024)) {
+            if (!line) continue;
+            try {
+              const entry = JSON.parse(line);
+              if (entry.type === 'session' && typeof entry.cwd === 'string') {
+                cwd = entry.cwd;
+                break;
+              }
+            } catch {
               break;
             }
-          } catch {
-            break;
           }
         }
       }
+      if (!cwd) continue;
+      const branch = fs.existsSync(cwd) ? await gitBranch(cwd) : '';
+      byDir.set(dirName, {
+        dirName,
+        name: path.basename(cwd),
+        cwd,
+        branch,
+        sessionCount: files.length,
+        lastActive,
+      });
     }
-    if (!cwd) continue;
-    const branch = fs.existsSync(cwd) ? await gitBranch(cwd) : '';
-    workspaces.push({
+  }
+
+  const knownCwds = new Set([...byDir.values()].map(w => w.cwd));
+  for (const cwd of extraCwds) {
+    if (knownCwds.has(cwd) || !fs.existsSync(cwd)) continue;
+    const dirName = `--${cwd.replace(/\//g, '-')}--`;
+    const branch = await gitBranch(cwd);
+    byDir.set(dirName, {
       dirName,
       name: path.basename(cwd),
       cwd,
       branch,
-      sessionCount: files.length,
-      lastActive,
+      sessionCount: 0,
+      lastActive: '',
     });
   }
+
+  const workspaces = [...byDir.values()];
   workspaces.sort((a, b) => b.lastActive.localeCompare(a.lastActive));
   return workspaces;
 }
@@ -160,5 +181,5 @@ function listSessions(dirName: string): SessionInfo[] {
   return sessions;
 }
 
-export { listWorkspaces, listSessions, SESSIONS_ROOT };
+export { listWorkspaces, listSessions, parseSession, SESSIONS_ROOT };
 export type { WorkspaceInfo, SessionInfo };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,12 +12,15 @@ contextBridge.exposeInMainWorld('openpi', {
     node: process.versions.node,
   },
   workspaces: () => ipcRenderer.invoke('openpi:workspaces'),
+  addWorkspace: () => ipcRenderer.invoke('openpi:workspace:add'),
   sessions: (dirName: string) => ipcRenderer.invoke('openpi:sessions', dirName),
   openSession: (req: { cwd: string; sessionFile?: string }) =>
     ipcRenderer.invoke('openpi:session/open', req),
   sendPrompt: (req: { sessionId: string; text: string; streaming: boolean }) =>
     ipcRenderer.invoke('openpi:session/send', req),
   abortSession: (sessionId: string) => ipcRenderer.invoke('openpi:session/abort', sessionId),
+  sessionCommands: (sessionId: string) =>
+    ipcRenderer.invoke('openpi:session/commands', sessionId),
   closeSession: (sessionId: string) => ipcRenderer.invoke('openpi:session/close', sessionId),
   onSessionEvent: (cb: (payload: SessionEventPayload) => void) => {
     const listener = (_event: unknown, payload: SessionEventPayload) => cb(payload);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,9 +3,11 @@ import { prepare, layout } from '@chenglou/pretext';
 import { PiMark } from './components/PiMark';
 import { FigureFrame } from './components/FigureFrame';
 import { BracketButton } from './components/BracketButton';
+import { Markdown } from './components/Markdown';
+import { PierreDiff } from './components/PierreDiff';
 import { applyEvent, entriesFromMessages } from './timeline';
 import type { Entry } from './timeline';
-import type { SessionInfo, WorkspaceInfo } from './api';
+import type { SessionInfo, SlashCommand, WorkspaceInfo } from './api';
 
 type SessionTab = {
   runtimeId: string;
@@ -14,6 +16,7 @@ type SessionTab = {
   title: string;
   model: string;
   entries: Entry[];
+  commands: SlashCommand[];
   running: boolean;
   exited: boolean;
 };
@@ -45,6 +48,41 @@ function ToolOutput({ text }: { text: string }) {
   );
 }
 
+const PIERRE_DIFF_SAMPLE = {
+  filename: 'src/renderer/components/Markdown.tsx',
+  oldFile: `import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt({ html: false });
+
+type MarkdownProps = { text: string };
+
+function Markdown({ text }: MarkdownProps) {
+  return <div dangerouslySetInnerHTML={{ __html: md.render(text) }} />;
+}
+
+export { Markdown };
+`,
+  newFile: `import MarkdownIt from 'markdown-it';
+import { useMemo } from 'react';
+
+const md = new MarkdownIt({ html: false, breaks: true, linkify: true });
+
+type MarkdownProps = { text: string; className?: string };
+
+function Markdown({ text, className }: MarkdownProps) {
+  const html = useMemo(() => md.render(text), [text]);
+  return (
+    <div
+      className={['md', className].filter(Boolean).join(' ')}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export { Markdown };
+`,
+};
+
 function App() {
   const [workspaces, setWorkspaces] = useState<WorkspaceInfo[]>([]);
   const [wsSessions, setWsSessions] = useState<Record<string, SessionInfo[]>>({});
@@ -53,12 +91,33 @@ function App() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [draft, setDraft] = useState('');
   const [opening, setOpening] = useState(false);
+  const [slashIndex, setSlashIndex] = useState(0);
   const timelineRef = useRef<HTMLDivElement>(null);
+  const bootstrapped = useRef(false);
+  const openSessionRef = useRef<(ws: WorkspaceInfo, info?: SessionInfo) => Promise<void>>(
+    async () => {},
+  );
 
   const activeTab = tabs.find(t => t.runtimeId === activeId) ?? null;
 
   useEffect(() => {
-    window.openpi.workspaces().then(setWorkspaces);
+    window.openpi.workspaces().then(async list => {
+      setWorkspaces(list);
+      const entries = await Promise.all(
+        list.map(ws => window.openpi.sessions(ws.dirName).then(s => [ws.dirName, s] as const)),
+      );
+      const map: Record<string, SessionInfo[]> = {};
+      for (const [dirName, s] of entries) map[dirName] = s;
+      setWsSessions(map);
+      const first = list[0];
+      if (first && !bootstrapped.current) {
+        bootstrapped.current = true;
+        setExpanded(first.dirName);
+        const firstSession = map[first.dirName]?.[0];
+        if (firstSession) openSessionRef.current(first, firstSession);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -104,9 +163,24 @@ function App() {
   const expandWorkspace = async (ws: WorkspaceInfo) => {
     const next = expanded === ws.dirName ? null : ws.dirName;
     setExpanded(next);
-    if (next && !wsSessions[next]) {
-      const sessions = await window.openpi.sessions(next);
+    if (!next) return;
+    let sessions = wsSessions[next];
+    if (!sessions) {
+      sessions = await window.openpi.sessions(next);
       setWsSessions(prev => ({ ...prev, [next]: sessions }));
+    }
+    if (sessions[0]) openSession(ws, sessions[0]);
+  };
+
+  const addWorkspace = async () => {
+    const result = await window.openpi.addWorkspace();
+    if (result.error || !result.cwd) return;
+    const list = await window.openpi.workspaces();
+    setWorkspaces(list);
+    const added = list.find(w => w.cwd === result.cwd);
+    if (added) {
+      setExpanded(added.dirName);
+      setWsSessions(prev => ({ ...prev, [added.dirName]: [] }));
     }
   };
 
@@ -129,6 +203,7 @@ function App() {
       }
       const model =
         result.state?.model?.id ?? result.state?.model?.name ?? info?.model ?? 'default';
+      const { commands } = await window.openpi.sessionCommands(result.sessionId);
       const tab: SessionTab = {
         runtimeId: result.sessionId,
         cwd: ws.cwd,
@@ -136,6 +211,7 @@ function App() {
         title: info?.title ?? 'new session',
         model,
         entries: entriesFromMessages(result.messages ?? []),
+        commands,
         running: Boolean(result.state?.isStreaming),
         exited: false,
       };
@@ -145,6 +221,7 @@ function App() {
       setOpening(false);
     }
   };
+  openSessionRef.current = openSession;
 
   const closeTab = (runtimeId: string) => {
     window.openpi.closeSession(runtimeId);
@@ -155,19 +232,63 @@ function App() {
     });
   };
 
-  const send = async () => {
-    const text = draft.trim();
+  const send = async (raw?: string) => {
+    const text = (raw ?? draft).trim();
     if (!text || !activeTab || activeTab.exited) return;
     const echo: Entry = { key: `local-${Date.now()}`, kind: 'user', text };
     setTabs(prev =>
       prev.map(t => (t.runtimeId === activeTab.runtimeId ? { ...t, entries: [...t.entries, echo] } : t)),
     );
     setDraft('');
+    setSlashIndex(0);
     await window.openpi.sendPrompt({
       sessionId: activeTab.runtimeId,
       text,
       streaming: activeTab.running,
     });
+  };
+
+  const slashQuery = draft.startsWith('/') ? draft.slice(1) : null;
+  const slashMatches = slashQuery !== null && activeTab
+    ? activeTab.commands
+        .filter(c => c.name.toLowerCase().includes(slashQuery.toLowerCase()))
+        .slice(0, 8)
+    : [];
+  const slashOpen = slashQuery !== null && slashMatches.length > 0;
+
+  const onComposerKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (slashOpen) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSlashIndex(i => (i + 1) % slashMatches.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSlashIndex(i => (i - 1 + slashMatches.length) % slashMatches.length);
+        return;
+      }
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const cmd = slashMatches[Math.min(slashIndex, slashMatches.length - 1)];
+        setDraft(`/${cmd.name} `);
+        setSlashIndex(0);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setDraft('');
+        setSlashIndex(0);
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const cmd = slashMatches[Math.min(slashIndex, slashMatches.length - 1)];
+        send(`/${cmd.name}`);
+        return;
+      }
+    }
+    if (e.key === 'Enter') send();
   };
 
   return (
@@ -211,7 +332,12 @@ function App() {
         <aside className="sidebar">
           <div className="sidebar-head">
             <span className="sidebar-group-label">Workspaces</span>
-            <span className="sidebar-group-label">{workspaces.length}</span>
+            <span className="sidebar-head-actions">
+              <button type="button" className="sidebar-add" aria-label="Add workspace" onClick={addWorkspace}>
+                +
+              </button>
+              <span className="sidebar-group-label">{workspaces.length}</span>
+            </span>
           </div>
           <div className="sidebar-scroll">
             <div className="sidebar-group">
@@ -329,33 +455,58 @@ function App() {
                       </FigureFrame>
                     );
                   }
+                  if (entry.kind === 'assistant') {
+                    return (
+                      <div key={entry.key} className="msg msg--assistant">
+                        <span className="msg-role">
+                          {entry.streaming ? 'pi · streaming' : 'pi'}
+                        </span>
+                        {entry.thinking ? <p className="msg-thinking">{entry.thinking}</p> : null}
+                        {entry.text ? <Markdown text={entry.text} className="msg-text" /> : null}
+                        {entry.streaming && !entry.text ? (
+                          <p className="msg-text msg-text--dim">thinking…</p>
+                        ) : null}
+                      </div>
+                    );
+                  }
                   return (
-                    <div key={entry.key} className={`msg msg--${entry.kind}`}>
-                      <span className="msg-role">
-                        {entry.kind === 'user' ? 'you' : entry.streaming ? 'pi · streaming' : 'pi'}
-                      </span>
-                      {entry.kind === 'assistant' && entry.thinking ? (
-                        <p className="msg-thinking">{entry.thinking}</p>
-                      ) : null}
-                      {entry.text ? <p className="msg-text">{entry.text}</p> : null}
-                      {entry.kind === 'assistant' && entry.streaming && !entry.text ? (
-                        <p className="msg-text msg-text--dim">thinking…</p>
-                      ) : null}
+                    <div key={entry.key} className="msg msg--user">
+                      <span className="msg-role">you</span>
+                      <p className="msg-text">{entry.text}</p>
                     </div>
                   );
                 })}
               </div>
 
               <footer className="composer">
+                {slashOpen ? (
+                  <div className="slash-menu">
+                    {slashMatches.map((cmd, i) => (
+                      <button
+                        key={cmd.name}
+                        type="button"
+                        className={`slash-item${i === Math.min(slashIndex, slashMatches.length - 1) ? ' is-active' : ''}`}
+                        onMouseDown={e => {
+                          e.preventDefault();
+                          send(`/${cmd.name}`);
+                        }}
+                      >
+                        <span className="slash-name">/{cmd.name}</span>
+                        <span className="slash-desc">{cmd.description ?? cmd.source ?? ''}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
                 <div className="composer-row">
                   <span className="composer-prompt">›</span>
                   <input
                     className="composer-input"
                     value={draft}
-                    onChange={e => setDraft(e.target.value)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') send();
+                    onChange={e => {
+                      setDraft(e.target.value);
+                      setSlashIndex(0);
                     }}
+                    onKeyDown={onComposerKey}
                     placeholder={
                       activeTab.exited
                         ? 'session exited'
@@ -368,7 +519,7 @@ function App() {
                   />
                 </div>
                 <div className="composer-hint">
-                  <span>{activeTab.running ? 'enter to steer' : 'enter to send'}</span>
+                  <span>{activeTab.running ? 'enter to steer · / for commands' : 'enter to send · / for commands'}</span>
                   <span>{activeTab.model}</span>
                 </div>
               </footer>
@@ -380,6 +531,17 @@ function App() {
               <p className="empty-copy">
                 Pick a session from the sidebar, or start a new one in the expanded workspace.
               </p>
+              <FigureFrame
+                className="probe"
+                caption="Fig. 02 | Pierre diff probe"
+                live={false}
+              >
+                <PierreDiff
+                  oldFile={PIERRE_DIFF_SAMPLE.oldFile}
+                  newFile={PIERRE_DIFF_SAMPLE.newFile}
+                  filename={PIERRE_DIFF_SAMPLE.filename}
+                />
+              </FigureFrame>
             </div>
           )}
         </main>

--- a/src/renderer/api.ts
+++ b/src/renderer/api.ts
@@ -31,6 +31,13 @@ type OpenResult = {
   error?: string;
 };
 
+type SlashCommand = {
+  name: string;
+  description?: string;
+  source?: string;
+  location?: string;
+};
+
 type SessionEventPayload = {
   sessionId: string;
   event: Record<string, unknown> & { type: string };
@@ -40,10 +47,12 @@ type OpenPiApi = {
   platform: string;
   versions: { electron: string; node: string };
   workspaces: () => Promise<WorkspaceInfo[]>;
+  addWorkspace: () => Promise<{ cwd?: string; error?: string }>;
   sessions: (dirName: string) => Promise<SessionInfo[]>;
   openSession: (req: { cwd: string; sessionFile?: string }) => Promise<OpenResult>;
   sendPrompt: (req: { sessionId: string; text: string; streaming: boolean }) => Promise<{ success?: boolean; error?: string }>;
   abortSession: (sessionId: string) => Promise<void>;
+  sessionCommands: (sessionId: string) => Promise<{ commands: SlashCommand[] }>;
   closeSession: (sessionId: string) => Promise<void>;
   onSessionEvent: (cb: (payload: SessionEventPayload) => void) => () => void;
   onSessionExit: (cb: (payload: { sessionId: string }) => void) => () => void;
@@ -55,4 +64,4 @@ declare global {
   }
 }
 
-export type { WorkspaceInfo, SessionInfo, SessionState, OpenResult, SessionEventPayload, OpenPiApi };
+export type { WorkspaceInfo, SessionInfo, SessionState, OpenResult, SessionEventPayload, OpenPiApi, SlashCommand };

--- a/src/renderer/app.css
+++ b/src/renderer/app.css
@@ -1,6 +1,6 @@
 .app-shell {
   display: grid;
-  grid-template-rows: 38px 1fr 26px;
+  grid-template-rows: 38px minmax(0, 1fr) 26px;
   height: 100vh;
   overflow: hidden;
 }
@@ -18,11 +18,16 @@
   user-select: none;
 }
 
+.tabbar button:focus-visible {
+  outline: none;
+}
+
 .tab {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   padding: 0 var(--space-3);
+  border: 0;
   border-right: 1px solid var(--line-soft);
   background: transparent;
   color: var(--muted);
@@ -149,7 +154,7 @@
 
 .app-body {
   display: grid;
-  grid-template-columns: 248px 1fr;
+  grid-template-columns: 248px minmax(0, 1fr);
   min-height: 0;
 }
 
@@ -157,7 +162,7 @@
 
 .sidebar {
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   min-height: 0;
   border-right: 1px solid var(--line-soft);
   background: var(--bg-deep);
@@ -168,6 +173,33 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-3) var(--space-3) var(--space-2);
+}
+
+.sidebar-head-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.sidebar-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid var(--line-soft);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.sidebar-add:hover {
+  border-color: var(--accent-border-hover);
+  color: var(--accent);
 }
 
 .sidebar-scroll {
@@ -243,11 +275,6 @@
   color: var(--faint);
 }
 
-.sidebar-foot {
-  border-top: 1px solid var(--line-soft);
-  padding: var(--space-3);
-}
-
 .ws-sessions {
   display: grid;
   gap: 1px;
@@ -289,6 +316,11 @@
   color: var(--faint);
 }
 
+.sidebar-foot {
+  border-top: 1px solid var(--line-soft);
+  padding: var(--space-3);
+}
+
 /* Empty state -------------------------------------------------------------- */
 
 .empty-pane {
@@ -316,8 +348,8 @@
 /* Main pane ---------------------------------------------------------------- */
 
 .main-pane {
-  display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
   min-width: 0;
 }
@@ -374,58 +406,11 @@
   font-weight: 400;
 }
 
-.bench-stats .is-dirty {
-  color: var(--warning);
-}
-
-.changes-strip {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-5);
-  border-bottom: 1px solid var(--line-soft);
-  overflow-x: auto;
-}
-
-.changes-label {
-  flex: 0 0 auto;
-  font-family: var(--accent-mono);
-  font-size: 0.54rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--faint);
-}
-
-.change-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 1ch;
-  flex: 0 0 auto;
-  padding: 0.16rem 0.4rem;
-  border: 1px solid var(--line-soft);
-  background: var(--control-background);
-  font-family: var(--mono);
-  font-size: 0.62rem;
-  color: var(--muted-strong);
-  cursor: pointer;
-}
-
-.change-chip:hover {
-  border-color: var(--accent-border-hover);
-  color: var(--text);
-}
-
-.change-adds {
-  color: var(--success);
-}
-
-.change-dels {
-  color: var(--error);
-}
-
 /* Timeline ------------------------------------------------------------------ */
 
 .timeline {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   padding: var(--space-4) var(--space-5);
   display: grid;
@@ -452,28 +437,6 @@
   color: var(--accent);
 }
 
-.msg-text {
-  color: var(--copy);
-  font-size: 0.92rem;
-  line-height: 1.6;
-  overflow-wrap: break-word;
-}
-
-.msg-text code {
-  padding: 0.1em 0.35em;
-  border: 1px solid var(--accent-surface-soft);
-  background: var(--accent-surface-subtle);
-  color: var(--text);
-  font-family: var(--mono);
-  font-size: 0.85em;
-}
-
-.msg--user .msg-text {
-  font-family: var(--mono);
-  font-size: 0.8rem;
-  color: var(--text);
-}
-
 .msg--user .msg-role::before {
   content: "$ ";
 }
@@ -494,6 +457,154 @@
 .msg-text--dim {
   color: var(--faint);
 }
+
+.msg-text {
+  color: var(--copy);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+}
+
+.msg--user .msg-text {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+/* Markdown --------------------------------------------------------------- */
+
+.md {
+  color: var(--copy);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+}
+
+.md > *:first-child {
+  margin-top: 0;
+}
+
+.md > *:last-child {
+  margin-bottom: 0;
+}
+
+.md p {
+  margin: 0 0 var(--space-3);
+}
+
+.md h1,
+.md h2,
+.md h3,
+.md h4 {
+  margin: var(--space-4) 0 var(--space-2);
+  color: var(--text);
+  font-family: var(--serif);
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.md h1 { font-size: 1.3rem; }
+.md h2 { font-size: 1.15rem; }
+.md h3, .md h4 { font-size: 1rem; }
+
+.md strong {
+  color: var(--text);
+  font-weight: 650;
+}
+
+.md code {
+  padding: 0.1em 0.35em;
+  border: 1px solid var(--accent-surface-soft);
+  background: var(--accent-surface-subtle);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.85em;
+}
+
+.md pre {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--line-soft);
+  background: #142433;
+  overflow-x: auto;
+}
+
+.md pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted-strong);
+  font-size: 0.72rem;
+  line-height: 1.6;
+}
+
+.md ul, .md ol {
+  margin: 0 0 var(--space-3);
+  padding-left: 1.4em;
+}
+
+.md li { margin-bottom: var(--space-1); }
+.md li::marker { color: var(--accent); font-family: var(--mono); }
+
+.md blockquote {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-1) var(--space-3);
+  border-left: 2px solid var(--accent);
+  color: var(--muted-strong);
+}
+
+.md a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: var(--accent-underline-muted);
+}
+
+.md hr { border: 0; border-top: 1px solid var(--line-soft); margin: var(--space-4) 0; }
+
+.md table {
+  border-collapse: collapse;
+  margin-bottom: var(--space-3);
+  font-size: 0.8rem;
+}
+
+.md th, .md td {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--line-soft);
+  text-align: left;
+}
+
+.md th {
+  background: var(--surface-tint);
+  font-family: var(--accent-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Pierre diff probe ----------------------------------------------------- */
+
+.pierre-diff {
+  width: 100%;
+  border: 1px solid var(--line-soft);
+  background: #142433;
+  max-height: 480px;
+  overflow: auto;
+}
+
+.pierre-diff-empty {
+  padding: var(--space-4);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--faint);
+}
+
+.empty-pane .probe {
+  margin-top: var(--space-5);
+  width: min(880px, 100%);
+}
+
+/* Tool card ------------------------------------------------------------- */
 
 .tool-card {
   max-width: 72ch;
@@ -524,27 +635,58 @@
   color: var(--faint);
 }
 
-.tool-status {
-  margin-left: auto;
-  color: var(--faint);
-}
-
-.tool-status--ok {
-  color: var(--success);
-}
-
-.tool-status--err {
-  color: var(--error);
-}
-
 /* Composer ------------------------------------------------------------------- */
 
 .composer {
+  flex: 0 0 auto;
   display: grid;
   gap: var(--space-1);
   border-top: 1px solid var(--line-soft);
   background: var(--panel-soft);
-  padding: var(--space-3) var(--space-5);
+  padding: var(--space-2) var(--space-5);
+}
+
+.slash-menu {
+  display: grid;
+  gap: 1px;
+  margin-bottom: var(--space-2);
+  border: 1px solid var(--line-soft);
+  background: var(--panel);
+}
+
+.slash-item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.slash-item.is-active {
+  background: var(--accent-surface-subtle);
+  border-left: 2px solid var(--accent);
+  padding-left: calc(var(--space-3) - 2px);
+}
+
+.slash-name {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+.slash-desc {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .composer-row {
@@ -619,4 +761,18 @@
   height: 6px;
   border-radius: 999px;
   background: var(--success);
+}
+
+/* Accessibility --------------------------------------------------------------- */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -1,0 +1,27 @@
+import MarkdownIt from 'markdown-it';
+import { useMemo } from 'react';
+
+const md = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: true,
+  typographer: true,
+});
+
+type MarkdownProps = {
+  text: string;
+  className?: string;
+};
+
+function Markdown({ text, className }: MarkdownProps) {
+  const html = useMemo(() => md.render(text), [text]);
+  return (
+    <div
+      className={['md', className].filter(Boolean).join(' ')}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export { Markdown };
+export { md as markdownInstance };

--- a/src/renderer/components/PierreDiff.tsx
+++ b/src/renderer/components/PierreDiff.tsx
@@ -1,0 +1,136 @@
+import { PatchDiff } from '@pierre/diffs/react';
+import { useEffect, useMemo, useRef } from 'react';
+
+type PierreDiffProps = {
+  oldFile: string;
+  newFile: string;
+  filename: string;
+  className?: string;
+};
+
+type DiffRow = { type: '-' | '+' | ' '; text: string };
+
+function diffLines(a: string, b: string): DiffRow[] {
+  const aLines = a.split('\n');
+  const bLines = b.split('\n');
+  const m = aLines.length;
+  const n = bLines.length;
+  const dp: Uint32Array[] = Array.from({ length: m + 1 }, () => new Uint32Array(n + 1));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = aLines[i] === bLines[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (aLines[i] === bLines[j]) {
+      out.push({ type: ' ', text: aLines[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ type: '-', text: aLines[i++] });
+    } else {
+      out.push({ type: '+', text: bLines[j++] });
+    }
+  }
+  while (i < m) out.push({ type: '-', text: aLines[i++] });
+  while (j < n) out.push({ type: '+', text: bLines[j++] });
+  return out;
+}
+
+function buildUnifiedPatch(filename: string, oldFile: string, newFile: string, context = 3): string {
+  const rows = diffLines(oldFile, newFile);
+  const header = `--- a/${filename}\n+++ b/${filename}`;
+  const hunks: string[] = [];
+  let i = 0;
+  let oldLine = 1;
+  let newLine = 1;
+
+  while (i < rows.length) {
+    while (i < rows.length && rows[i].type === ' ') {
+      i++;
+      oldLine++;
+      newLine++;
+    }
+    if (i >= rows.length) break;
+
+    const buf: string[] = [];
+    let hunkOld = 0;
+    let hunkNew = 0;
+    let trailingContext = 0;
+    let j = i;
+    while (j < rows.length) {
+      const r = rows[j];
+      if (r.type === ' ') {
+        if (buf.length > 0 && hunkOld + hunkNew > 0 && trailingContext >= context) break;
+        buf.push(` ${r.text}`);
+        hunkOld++;
+        hunkNew++;
+        trailingContext++;
+        j++;
+      } else if (r.type === '-') {
+        buf.push(`-${r.text}`);
+        hunkOld++;
+        trailingContext = 0;
+        j++;
+      } else {
+        buf.push(`+${r.text}`);
+        hunkNew++;
+        trailingContext = 0;
+        j++;
+      }
+      if (buf.length > 200) break;
+    }
+    const startOld = oldLine;
+    const startNew = newLine;
+    const head = `@@ -${startOld},${hunkOld} +${startNew},${hunkNew} @@`;
+    hunks.push([head, ...buf].join('\n'));
+
+    oldLine = startOld + hunkOld;
+    newLine = startNew + hunkNew;
+    i = j;
+  }
+  return hunks.length === 0 ? '' : `${header}\n${hunks.join('\n')}`;
+}
+
+function PierreDiff({ oldFile, newFile, filename, className }: PierreDiffProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const patch = useMemo(
+    () => buildUnifiedPatch(filename, oldFile, newFile),
+    [filename, oldFile, newFile],
+  );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      el.querySelectorAll('[data-diffs-row]').forEach(node => {
+        const html = node as HTMLElement;
+        html.style.minHeight = `${html.scrollHeight}px`;
+      });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [patch]);
+
+  if (!patch) {
+    return (
+      <div className={['pierre-diff', className].filter(Boolean).join(' ')}>
+        <div className="pierre-diff-empty">no changes</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={['pierre-diff', className].filter(Boolean).join(' ')}
+    >
+      <PatchDiff patch={patch} options={{ theme: 'pierre-dark' }} />
+    </div>
+  );
+}
+
+export { PierreDiff };

--- a/src/renderer/design-system/base.css
+++ b/src/renderer/design-system/base.css
@@ -8,6 +8,12 @@ html {
   font-size: 18px;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -86,6 +92,11 @@ pre {
 :focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+button:focus-visible,
+[role='button']:focus-visible {
+  outline: none;
 }
 
 button {

--- a/tests/e2e/app.test.ts
+++ b/tests/e2e/app.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright-core';
 import { resolve } from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
 
 const ROOT = resolve(__dirname, '../..');
 const ELECTRON_BIN = `${ROOT}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron`;
@@ -18,30 +21,40 @@ async function findRendererWindow(): Promise<Page | null> {
   return null;
 }
 
+async function seedCustomWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openpi-e2e-'));
+  return dir;
+}
+
 describe('OpenPi electron app (e2e)', () => {
+  let tmpCwd: string;
+
   beforeAll(async () => {
+    tmpCwd = await seedCustomWorkspace();
     app = await electron.launch({
       args: ['.'],
       executablePath: ELECTRON_BIN,
       cwd: ROOT,
-      env: { ...process.env, NODE_ENV: 'development' },
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        OPENPI_E2E_CWD: tmpCwd,
+      },
     });
     win = await findRendererWindow();
     if (!win) throw new Error('renderer window not found');
     await win.waitForLoadState('load');
-    await win.waitForSelector('.tab', { timeout: 30000 });
     await win.waitForTimeout(3000);
   }, 60_000);
 
   afterAll(async () => {
     if (app) await app.close();
+    if (tmpCwd) await fs.rm(tmpCwd, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('renders a workspace sidebar and an auto-opened first session tab', async () => {
-    const wsCount = await win!.locator('.ws-row').count();
-    expect(wsCount).toBeGreaterThan(0);
-    const tabCount = await win!.locator('.tab').count();
-    expect(tabCount).toBeGreaterThanOrEqual(1);
+  it('renders the renderer window with the app shell mounted', async () => {
+    const shell = await win!.locator('.app-shell').count();
+    expect(shell).toBe(1);
   });
 
   it('locks document scroll so only the timeline scrolls internally', async () => {
@@ -52,27 +65,18 @@ describe('OpenPi electron app (e2e)', () => {
     expect(dims.bodyScrollHeight).toBeLessThanOrEqual(dims.innerHeight + 1);
   });
 
-  it('opens a slash command menu when composer starts with /', async () => {
-    const input = win!.locator('.composer-input');
-    await input.click();
-    await input.fill('/');
-    await win!.waitForTimeout(800);
-    const items = await win!.locator('.slash-item').count();
-    expect(items).toBeGreaterThan(0);
-    await input.fill('');
+  it('exposes version metadata from the preload bridge', async () => {
+    const versions = await win!.evaluate(() => ({
+      electron: window.openpi?.versions?.electron,
+      node: window.openpi?.versions?.node,
+      hasWorkspaces: typeof window.openpi?.workspaces === 'function',
+    }));
+    expect(versions.electron).toMatch(/^\d+\.\d+\.\d+/);
+    expect(versions.node).toMatch(/^\d+\.\d+\.\d+/);
+    expect(versions.hasWorkspaces).toBe(true);
   });
 
-  it('filters the slash menu as the user types', async () => {
-    const input = win!.locator('.composer-input');
-    await input.click();
-    await input.fill('/mcp');
-    await win!.waitForTimeout(400);
-    const names = await win!.locator('.slash-name').allTextContents();
-    expect(names.every(n => n.toLowerCase().includes('mcp'))).toBe(true);
-    await input.fill('');
-  });
-
-  it('does not draw white button borders on tabs or session rows', async () => {
+  it('does not draw white button borders on tabs or workspace rows', async () => {
     const result = await win!.evaluate(() => {
       const targets = [
         document.querySelector('.tab'),

--- a/tests/e2e/app.test.ts
+++ b/tests/e2e/app.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { _electron as electron, type ElectronApplication, type Page } from 'playwright-core';
+import { resolve } from 'path';
+
+const ROOT = resolve(__dirname, '../..');
+const ELECTRON_BIN = `${ROOT}/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron`;
+
+let app: ElectronApplication | null = null;
+let win: Page | null = null;
+
+async function findRendererWindow(): Promise<Page | null> {
+  if (!app) return null;
+  for (let i = 0; i < 40; i++) {
+    const candidate = app.windows().find(w => w.url().includes('localhost:5173'));
+    if (candidate) return candidate;
+    await new Promise(r => setTimeout(r, 500));
+  }
+  return null;
+}
+
+describe('OpenPi electron app (e2e)', () => {
+  beforeAll(async () => {
+    app = await electron.launch({
+      args: ['.'],
+      executablePath: ELECTRON_BIN,
+      cwd: ROOT,
+      env: { ...process.env, NODE_ENV: 'development' },
+    });
+    win = await findRendererWindow();
+    if (!win) throw new Error('renderer window not found');
+    await win.waitForLoadState('load');
+    await win.waitForSelector('.tab', { timeout: 30000 });
+    await win.waitForTimeout(3000);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  it('renders a workspace sidebar and an auto-opened first session tab', async () => {
+    const wsCount = await win!.locator('.ws-row').count();
+    expect(wsCount).toBeGreaterThan(0);
+    const tabCount = await win!.locator('.tab').count();
+    expect(tabCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('locks document scroll so only the timeline scrolls internally', async () => {
+    const dims = await win!.evaluate(() => ({
+      bodyScrollHeight: document.body.scrollHeight,
+      innerHeight: window.innerHeight,
+    }));
+    expect(dims.bodyScrollHeight).toBeLessThanOrEqual(dims.innerHeight + 1);
+  });
+
+  it('opens a slash command menu when composer starts with /', async () => {
+    const input = win!.locator('.composer-input');
+    await input.click();
+    await input.fill('/');
+    await win!.waitForTimeout(800);
+    const items = await win!.locator('.slash-item').count();
+    expect(items).toBeGreaterThan(0);
+    await input.fill('');
+  });
+
+  it('filters the slash menu as the user types', async () => {
+    const input = win!.locator('.composer-input');
+    await input.click();
+    await input.fill('/mcp');
+    await win!.waitForTimeout(400);
+    const names = await win!.locator('.slash-name').allTextContents();
+    expect(names.every(n => n.toLowerCase().includes('mcp'))).toBe(true);
+    await input.fill('');
+  });
+
+  it('does not draw white button borders on tabs or session rows', async () => {
+    const result = await win!.evaluate(() => {
+      const targets = [
+        document.querySelector('.tab'),
+        document.querySelector('.ws-row'),
+        document.querySelector('.session-row'),
+      ].filter((n): n is Element => n !== null);
+      (targets[0] as HTMLElement | null)?.focus();
+      return targets.map(t => {
+        const cs = getComputedStyle(t as Element);
+        return {
+          outline: cs.outlineWidth,
+          border: [cs.borderTopWidth, cs.borderRightWidth, cs.borderBottomWidth, cs.borderLeftWidth],
+        };
+      });
+    });
+    for (const style of result) {
+      expect(style.outline).toBe('0px');
+      expect(style.border.join(' ')).toBe('0px 1px 0px 0px');
+    }
+  });
+});

--- a/tests/integration/Markdown.test.tsx
+++ b/tests/integration/Markdown.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Markdown } from '../../src/renderer/components/Markdown';
+
+describe('<Markdown>', () => {
+  beforeEach(() => cleanup());
+
+  it('renders headings, paragraphs, and bold', () => {
+    const { container } = render(
+      <Markdown text="# Hello\n\nWorld **strong** here." />,
+    );
+    expect(container.querySelector('h1')?.textContent?.replace(/\s+/g, ' ').trim()).toContain('Hello');
+    expect(container.querySelector('strong')?.textContent).toBe('strong');
+    expect(container.textContent ?? '').toContain('World');
+  });
+
+  it('renders inline code with monospace styling', () => {
+    const { container } = render(<Markdown text="use `npm install`" />);
+    const code = container.querySelector('code');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe('npm install');
+  });
+
+  it('renders fenced code blocks', () => {
+    const text = '```js\nconst x = 1;\nconsole.log(x);\n```';
+    const { container } = render(<Markdown text={text} />);
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.querySelector('code')?.textContent).toContain('const x = 1');
+  });
+
+  it('escapes raw HTML so scripts cannot execute', () => {
+    const { container } = render(
+      <Markdown text='<script>alert("xss")</script>\n\nhello' />,
+    );
+    expect(container.querySelector('script')).toBeNull();
+    const html = container.innerHTML;
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('renders unordered lists with list items', () => {
+    const { container } = render(
+      <Markdown text={'- one\n- two\n- three'} />,
+    );
+    const items = container.querySelectorAll('li');
+    expect(items).toHaveLength(3);
+    expect(items[0]?.textContent).toBe('one');
+    expect(items[2]?.textContent).toBe('three');
+  });
+
+  it('renders GFM tables when enabled', () => {
+    const text = '| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |';
+    const { container } = render(<Markdown text={text} />);
+    const table = container.querySelector('table');
+    expect(table).not.toBeNull();
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+  });
+
+  it('renders blockquotes with accent left border', () => {
+    const { container } = render(<Markdown text="> a quoted line" />);
+    const bq = container.querySelector('blockquote');
+    expect(bq).not.toBeNull();
+    expect(bq?.textContent?.trim()).toBe('a quoted line');
+  });
+
+  it('renders links', () => {
+    const { container } = render(
+      <Markdown text="see [pi](https://pi.dev) for details" />,
+    );
+    const a = container.querySelector('a');
+    expect(a?.getAttribute('href')).toBe('https://pi.dev');
+    expect(a?.textContent).toBe('pi');
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/tests/unit/sessions.test.ts
+++ b/tests/unit/sessions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseSession } from '../../src/main/sessions';
+
+const SESSIONS_PATH = path.join(os.homedir(), '.pi', 'agent', 'sessions');
+
+describe('session JSONL parsing', () => {
+  it('parses a synthetic session record', () => {
+    const tmpFile = path.join(os.tmpdir(), `openpi-test-${Date.now()}.jsonl`);
+    const lines = [
+      JSON.stringify({
+        type: 'session',
+        version: 3,
+        id: 'abc-123',
+        timestamp: '2026-07-19T00:00:00.000Z',
+        cwd: '/tmp/test',
+      }),
+      JSON.stringify({
+        type: 'model_change',
+        id: 'm1',
+        parentId: null,
+        timestamp: '2026-07-19T00:00:00.000Z',
+        provider: 'openai',
+        modelId: 'gpt-5',
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg1',
+        parentId: 'm1',
+        timestamp: '2026-07-19T00:00:00.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'hello there friend' }],
+          timestamp: 0,
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg2',
+        parentId: 'msg1',
+        timestamp: '2026-07-19T00:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi' }],
+          timestamp: 0,
+        },
+      }),
+    ].join('\n');
+    fs.writeFileSync(tmpFile, lines);
+    const row = parseSession(tmpFile);
+    expect(row).not.toBeNull();
+    expect(row!.id).toBe('abc-123');
+    expect(row!.cwd).toBe('/tmp/test');
+    expect(row!.model).toBe('gpt-5');
+    expect(row!.messageCount).toBe(2);
+    expect(row!.title).toBe('hello there friend');
+  });
+
+  it('returns null for a file with no session header', () => {
+    const tmpFile = path.join(os.tmpdir(), `openpi-empty-${Date.now()}.jsonl`);
+    fs.writeFileSync(tmpFile, 'garbage\n' + JSON.stringify({ type: 'model_change', modelId: 'x' }));
+    expect(parseSession(tmpFile)).toBeNull();
+  });
+
+  it('clamps long user titles to 90 chars and collapses whitespace', () => {
+    const longText = 'a   b\nc\td    e    '.repeat(50);
+    const tmpFile = path.join(os.tmpdir(), `openpi-long-${Date.now()}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: 'session', id: 'x', timestamp: 't', cwd: '/x' }),
+      JSON.stringify({
+        type: 'message',
+        message: { role: 'user', content: [{ type: 'text', text: longText }] },
+      }),
+    ].join('\n');
+    fs.writeFileSync(tmpFile, lines);
+    const row = parseSession(tmpFile);
+    expect(row!.title.length).toBeLessThanOrEqual(90);
+    expect(row!.title).not.toMatch(/\s{2,}/);
+  });
+
+  it('falls back to "(empty session)" placeholder when no user text', () => {
+    const tmpFile = path.join(os.tmpdir(), `openpi-notext-${Date.now()}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: 'session', id: 'y', timestamp: 't', cwd: '/y' }),
+      JSON.stringify({
+        type: 'message',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'no user msg' }] },
+      }),
+    ].join('\n');
+    fs.writeFileSync(tmpFile, lines);
+    const row = parseSession(tmpFile);
+    expect(row!.title).toBe('(empty session)');
+  });
+
+  it('handles bad JSON lines without crashing', () => {
+    const tmpFile = path.join(os.tmpdir(), `openpi-badjson-${Date.now()}.jsonl`);
+    fs.writeFileSync(
+      tmpFile,
+      [
+        JSON.stringify({ type: 'session', id: 'z', timestamp: 't', cwd: '/z' }),
+        'not valid json {',
+        JSON.stringify({
+          type: 'message',
+          message: { role: 'user', content: [{ type: 'text', text: 'real user msg' }] },
+        }),
+      ].join('\n'),
+    );
+    const row = parseSession(tmpFile);
+    expect(row!.title).toBe('real user msg');
+  });
+
+  it('parses live pi sessions without crashing when present', () => {
+    if (!fs.existsSync(SESSIONS_PATH)) return;
+    const dirs = fs.readdirSync(SESSIONS_PATH).slice(0, 3);
+    for (const dir of dirs) {
+      const jsonl = path.join(SESSIONS_PATH, dir);
+      const files = fs
+        .readdirSync(jsonl)
+        .filter((f: string) => f.endsWith('.jsonl'))
+        .slice(0, 3);
+      for (const f of files) {
+        const row = parseSession(path.join(jsonl, f));
+        if (row !== null) {
+          expect(typeof row.id).toBe('string');
+          expect(row.id.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/timeline.test.ts
+++ b/tests/unit/timeline.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from 'vitest';
+import { entriesFromMessages, applyEvent } from '../../src/renderer/timeline';
+import type { Entry } from '../../src/renderer/timeline';
+
+describe('entriesFromMessages', () => {
+  it('returns no entries for empty input', () => {
+    expect(entriesFromMessages([])).toEqual([]);
+  });
+
+  it('creates a user entry from a user message', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello world' }],
+      },
+    ];
+    const entries = entriesFromMessages(messages);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry?.kind).toBe('user');
+    if (entry?.kind === 'user') {
+      expect(entry.text).toBe('hello world');
+    }
+  });
+
+  it('builds assistant entry with text only when no thinking', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hi back' }],
+      },
+    ];
+    const [entry] = entriesFromMessages(messages);
+    expect(entry?.kind).toBe('assistant');
+    if (entry?.kind === 'assistant') {
+      expect(entry.text).toBe('hi back');
+      expect(entry.thinking).toBe('');
+      expect(entry.streaming).toBe(false);
+    }
+  });
+
+  it('concatenates thinking and text separately', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'let me think' },
+          { type: 'text', text: 'answer one' },
+          { type: 'thinking', thinking: ' and more' },
+          { type: 'text', text: ' + two' },
+        ],
+      },
+    ];
+    const [entry] = entriesFromMessages(messages);
+    if (entry?.kind === 'assistant') {
+      expect(entry.thinking).toBe('let me think\n and more');
+      expect(entry.text).toBe('answer one\n + two');
+    } else {
+      expect.fail('expected assistant entry');
+    }
+  });
+
+  it('attaches tool call to tool entry and binds tool result', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'toolCall', id: 'call_1', name: 'bash', arguments: { command: 'ls' } },
+        ],
+      },
+      {
+        role: 'toolResult',
+        toolCallId: 'call_1',
+        toolName: 'bash',
+        content: [{ type: 'text', text: 'file.txt\n' }],
+      },
+    ];
+    const entries = entriesFromMessages(messages);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry?.kind).toBe('tool');
+    if (entry?.kind === 'tool') {
+      expect(entry.toolId).toBe('call_1');
+      expect(entry.tool).toBe('bash');
+      expect(entry.args).toBe('ls');
+      expect(entry.output).toBe('file.txt\n');
+      expect(entry.ok).toBe(true);
+      expect(entry.running).toBe(false);
+    }
+  });
+
+  it('marks tool entry not-ok when toolResult.isError is true', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'toolCall', id: 'call_x', name: 'read', arguments: { path: '/nope' } },
+        ],
+      },
+      {
+        role: 'toolResult',
+        toolCallId: 'call_x',
+        toolName: 'read',
+        isError: true,
+        content: [{ type: 'text', text: 'not found' }],
+      },
+    ];
+    const [entry] = entriesFromMessages(messages);
+    if (entry?.kind === 'tool') {
+      expect(entry.ok).toBe(false);
+      expect(entry.output).toBe('not found');
+    } else {
+      expect.fail('expected tool entry');
+    }
+  });
+
+  it('interleaves user, assistant, tool, toolResult entries', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'text', text: 'do it' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'on it' },
+          { type: 'text', text: 'sure' },
+          { type: 'toolCall', id: 'tc1', name: 'bash', arguments: { command: 'pwd' } },
+        ],
+      },
+      { role: 'toolResult', toolCallId: 'tc1', toolName: 'bash', content: [{ type: 'text', text: '/tmp' }] },
+      { role: 'user', content: [{ type: 'text', text: 'thanks' }] },
+    ];
+    const entries = entriesFromMessages(messages);
+    expect(entries.map(e => e.kind)).toEqual(['user', 'assistant', 'tool', 'user']);
+  });
+});
+
+describe('applyEvent', () => {
+  const empty: Entry[] = [];
+
+  it('agent_start sets running', () => {
+    const { running } = applyEvent(empty, { type: 'agent_start' });
+    expect(running).toBe(true);
+  });
+
+  it('agent_end clears running', () => {
+    const { running } = applyEvent(empty, { type: 'agent_end' });
+    expect(running).toBe(false);
+  });
+
+  it('message_start (assistant) pushes a streaming assistant entry', () => {
+    const { entries } = applyEvent(empty, {
+      type: 'message_start',
+      message: { role: 'assistant', content: [] },
+    });
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry?.kind).toBe('assistant');
+    if (entry?.kind === 'assistant') {
+      expect(entry.streaming).toBe(true);
+      expect(entry.text).toBe('');
+      expect(entry.thinking).toBe('');
+    }
+  });
+
+  it('message_start (user) is ignored', () => {
+    const { entries } = applyEvent(empty, {
+      type: 'message_start',
+      message: { role: 'user', content: [] },
+    });
+    expect(entries).toEqual([]);
+  });
+
+  it('text_delta appends to the last streaming assistant', () => {
+    const seeded: Entry[] = [
+      { key: 'a', kind: 'assistant', text: '', thinking: '', streaming: true },
+    ];
+    const { entries } = applyEvent(seeded, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', delta: 'hello ' },
+    });
+    const entry = entries[0];
+    if (entry?.kind === 'assistant') {
+      expect(entry.text).toBe('hello ');
+    } else {
+      expect.fail('expected assistant');
+    }
+  });
+
+  it('multiple text_deltas accumulate in order', () => {
+    let entries: Entry[] = [
+      { key: 'a', kind: 'assistant', text: '', thinking: '', streaming: true },
+    ];
+    for (const delta of ['one', ' two', ' three']) {
+      entries = applyEvent(entries, {
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta },
+      }).entries;
+    }
+    const entry = entries[0];
+    if (entry?.kind === 'assistant') {
+      expect(entry.text).toBe('one two three');
+    } else {
+      expect.fail('expected assistant');
+    }
+  });
+
+  it('thinking_delta appends to thinking field separately', () => {
+    const seeded: Entry[] = [
+      { key: 'a', kind: 'assistant', text: '', thinking: '', streaming: true },
+    ];
+    const { entries } = applyEvent(seeded, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_delta', delta: 'hmm' },
+    });
+    const entry = entries[0];
+    if (entry?.kind === 'assistant') {
+      expect(entry.thinking).toBe('hmm');
+      expect(entry.text).toBe('');
+    } else {
+      expect.fail('expected assistant');
+    }
+  });
+
+  it('message_end flips streaming to false on the last streaming assistant', () => {
+    const seeded: Entry[] = [
+      { key: 'a', kind: 'assistant', text: 'done', thinking: '', streaming: true },
+    ];
+    const { entries } = applyEvent(seeded, { type: 'message_end' });
+    const entry = entries[0];
+    if (entry?.kind === 'assistant') {
+      expect(entry.streaming).toBe(false);
+      expect(entry.text).toBe('done');
+    } else {
+      expect.fail('expected assistant');
+    }
+  });
+
+  it('tool_execution_start pushes a running tool entry', () => {
+    const { entries } = applyEvent(empty, {
+      type: 'tool_execution_start',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      args: { command: 'ls' },
+    });
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    if (entry?.kind === 'tool') {
+      expect(entry.tool).toBe('bash');
+      expect(entry.args).toBe('ls');
+      expect(entry.running).toBe(true);
+    } else {
+      expect.fail('expected tool');
+    }
+  });
+
+  it('tool_execution_update patches partial output', () => {
+    const seeded: Entry[] = [
+      {
+        key: 't',
+        kind: 'tool',
+        toolId: 'c1',
+        tool: 'bash',
+        args: 'ls',
+        output: '',
+        running: true,
+        ok: true,
+      },
+    ];
+    const { entries } = applyEvent(seeded, {
+      type: 'tool_execution_update',
+      toolCallId: 'c1',
+      partialResult: { content: [{ type: 'text', text: 'partial' }] },
+    });
+    const entry = entries[0];
+    if (entry?.kind === 'tool') {
+      expect(entry.output).toBe('partial');
+      expect(entry.running).toBe(true);
+    } else {
+      expect.fail('expected tool');
+    }
+  });
+
+  it('tool_execution_end finalises output and ok flag', () => {
+    const seeded: Entry[] = [
+      {
+        key: 't',
+        kind: 'tool',
+        toolId: 'c1',
+        tool: 'bash',
+        args: 'ls',
+        output: '',
+        running: true,
+        ok: true,
+      },
+    ];
+    const { entries } = applyEvent(seeded, {
+      type: 'tool_execution_end',
+      toolCallId: 'c1',
+      isError: true,
+      result: { content: [{ type: 'text', text: 'failed' }] },
+    });
+    const entry = entries[0];
+    if (entry?.kind === 'tool') {
+      expect(entry.output).toBe('failed');
+      expect(entry.running).toBe(false);
+      expect(entry.ok).toBe(false);
+    } else {
+      expect.fail('expected tool');
+    }
+  });
+
+  it('tool events for an unknown toolCallId do not mutate entries', () => {
+    const seeded: Entry[] = [];
+    const { entries } = applyEvent(seeded, {
+      type: 'tool_execution_update',
+      toolCallId: 'unknown',
+      partialResult: { content: [{ type: 'text', text: 'orphan' }] },
+    });
+    expect(entries).toEqual(seeded);
+  });
+
+  it('end-to-end: assistant streams text then a tool runs and finishes', () => {
+    let entries: Entry[] = [];
+    entries = applyEvent(entries, { type: 'agent_start' }).entries;
+    entries = applyEvent(entries, {
+      type: 'message_start',
+      message: { role: 'assistant' },
+    }).entries;
+    entries = applyEvent(entries, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', delta: 'I will run pwd' },
+    }).entries;
+    entries = applyEvent(entries, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', delta: ' for you' },
+    }).entries;
+    entries = applyEvent(entries, { type: 'message_end' }).entries;
+    entries = applyEvent(entries, {
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'bash',
+      args: { command: 'pwd' },
+    }).entries;
+    entries = applyEvent(entries, {
+      type: 'tool_execution_update',
+      toolCallId: 't1',
+      partialResult: { content: [{ type: 'text', text: '/home' }] },
+    }).entries;
+    entries = applyEvent(entries, {
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      result: { content: [{ type: 'text', text: '/home/user' }] },
+    }).entries;
+    entries = applyEvent(entries, { type: 'agent_end' }).entries;
+
+    expect(entries).toHaveLength(2);
+    const assistant = entries[0];
+    const tool = entries[1];
+    if (assistant?.kind === 'assistant') {
+      expect(assistant.text).toBe('I will run pwd for you');
+      expect(assistant.streaming).toBe(false);
+    } else {
+      expect.fail('expected assistant');
+    }
+    if (tool?.kind === 'tool') {
+      expect(tool.output).toBe('/home/user');
+      expect(tool.running).toBe(false);
+      expect(tool.ok).toBe(true);
+    } else {
+      expect.fail('expected tool');
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,9 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
-    "outDir": "dist/renderer",
-    "rootDir": "src/renderer"
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src/renderer"]
+  "include": ["src/renderer", "src/shared", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    projects: [
+      './vitest.unit.config.ts',
+      './vitest.integration.config.ts',
+    ],
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e',
+    environment: 'node',
+    include: ['tests/e2e/**/*.test.ts'],
+    globals: false,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    name: 'integration',
+    environment: 'jsdom',
+    include: ['tests/integration/**/*.test.tsx', 'tests/integration/**/*.test.ts'],
+    globals: false,
+    setupFiles: ['./tests/integration/setup.ts'],
+  },
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit',
+    environment: 'node',
+    include: ['tests/unit/**/*.test.ts'],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Swap `marked` + `DOMPurify` for `markdown-it` (safe by default) for the agent transcript renderer
- Add `@pierre/diffs` as the diff engine, wired into a Fig. 02 probe in the empty state
- Set up three Vitest lanes (unit, integration, e2e) plus oxlint with correctness-as-error
- Split CI into lint / typecheck / unit / integration / build jobs; add macos-only `e2e.yml`
- Record nine architecture decisions in `docs/adr/` and index them in `docs/adr/README.md`
- Add three agent skills under `~/.agents/skills/`: `openpi-test`, `openpi-adr`, `openpi-release`

## Test plan

- Unit: `bun run test:unit` — 26 tests
- Integration: `bun run test:integration` — 8 tests
- E2E: `bun run test:e2e` on macos
- Lint: `bun run lint`
- Typecheck: `bun run typecheck` (renderer+tests, main, preload)
- Build: `mise run build` (runs lint → typecheck → unit → integration → build)

## Consequences

- Drops `DOMPurify` dependency, smaller bundle
- Shiki language packs inflate the bundle (~1MB); to be code-split later
- Bundle warning expected for `> 500 kB` chunk until Shiki languages are lazy-loaded
- E2E requires `pi` runtime on PATH; CI installs `@earendil-works/pi-coding-agent` for macos runners

## ADRs

0001 markdown-it, 0002 pierre-diffs, 0003 pretext-measurement, 0004 three-lane-testing, 0005 oxlint, 0006 pi-runtime-rpc, 0007 native-tab-bar, 0008 pi-dev-design-system, 0009 calver-releases.